### PR TITLE
Updated support info

### DIFF
--- a/info.json
+++ b/info.json
@@ -19,7 +19,7 @@
     "description": "SOC Simulator Solution Pack",
     "help": "https:\/\/github.com\/fortinet-fortisoar\/solution-pack-soc-simulator\/blob\/develop\/README.md",
     "category": [],
-    "supportInfo": "support@fortinet.com",
+    "supportInfo": "Fortinet Customer Support",
     "iconLarge": null,
     "fsrMinCompatibility": "7.2.0",
     "date": "2022-03-28T14:00:59+00:00",


### PR DESCRIPTION
Updated support info from "support@fortinet.com" to "Fortinet Customer Support"