### PR TITLE
BugFixes-1

### DIFF
--- a/playbooks/02 - Use Case - SOC Simulator/Reset Scenario - Get Correlated Records.json
+++ b/playbooks/02 - Use Case - SOC Simulator/Reset Scenario - Get Correlated Records.json
@@ -163,10 +163,10 @@
             "arguments": {
                 "params": {
                     "iri": "\/api\/query\/attribute_metadatas",
-                    "body": "{\n  \"sort\": [],\n  \"filters\": [\n    {\n      \"field\": \"formType\",\n      \"operator\": \"eq\",\n      \"type\": \"array\",\n      \"value\": \"manyToMany\"\n    },\n    {\n      \"field\": \"sattrib.type\",\n      \"operator\": \"eq\",\n      \"value\": \"{{vars.moduleName}}\"\n    }\n  ],\n  \"logic\": \"AND\"\n}",
+                    "body": "{\n  \"sort\": [],\n  \"filters\": [\n    {\n      \"field\": \"type\",\n      \"operator\": \"notlike\",\n      \"value\": \"%mitre%\"\n    },\n    {\n      \"field\": \"formType\",\n      \"operator\": \"eq\",\n      \"type\": \"array\",\n      \"value\": \"manyToMany\"\n    },\n    {\n      \"field\": \"sattrib.type\",\n      \"operator\": \"eq\",\n      \"value\": \"{{vars.moduleName}}\"\n    }\n  ],\n  \"logic\": \"AND\"\n}",
                     "method": "POST"
                 },
-                "version": "3.2.3",
+                "version": "3.2.6",
                 "connector": "cyops_utilities",
                 "operation": "make_cyops_request",
                 "operationTitle": "FSR: Make FortiSOAR API Call",

--- a/playbooks/02 - Use Case - SOC Simulator/Reset Scenario.json
+++ b/playbooks/02 - Use Case - SOC Simulator/Reset Scenario.json
@@ -418,6 +418,7 @@
     "deletedAt": null,
     "recordTags": [
         "Simulation",
-        "Cleanup"
+        "Cleanup",
+        "SystemWaitForCompletion"
     ]
 }

--- a/playbooks/02 - Use Case - SOC Simulator/Run Scenario - Create Alerts.json
+++ b/playbooks/02 - Use Case - SOC Simulator/Run Scenario - Create Alerts.json
@@ -39,7 +39,7 @@
             "name": "Format Record List",
             "description": null,
             "arguments": {
-                "formatted_alert_list": "{{vars.createdAlertId + [vars.alertIRI]}}"
+                "formatted_alert_list": "{{(vars.createdAlertId + [vars.alertIRI]) | flatten(levels=1) | unique}}"
             },
             "status": null,
             "top": "1380",

--- a/playbooks/02 - Use Case - SOC Simulator/Run Scenario - Create Alerts.json
+++ b/playbooks/02 - Use Case - SOC Simulator/Run Scenario - Create Alerts.json
@@ -254,6 +254,8 @@
                 "arguments": [],
                 "apply_async": false,
                 "step_variables": [],
+                "pass_parent_env": false,
+                "pass_input_record": true,
                 "workflowReference": "{{vars.alert_Steps.playbookIRI}}"
             },
             "status": null,

--- a/playbooks/02 - Use Case - SOC Simulator/Run Scenario.json
+++ b/playbooks/02 - Use Case - SOC Simulator/Run Scenario.json
@@ -141,6 +141,7 @@
     "isPrivate": false,
     "deletedAt": null,
     "recordTags": [
-        "Simulation"
+        "Simulation",
+        "SystemWaitForCompletion"
     ]
 }

--- a/playbooks/02 - Use Case - SOC Simulator/Run Selected Scenario.json
+++ b/playbooks/02 - Use Case - SOC Simulator/Run Selected Scenario.json
@@ -195,6 +195,7 @@
     "isPrivate": false,
     "deletedAt": null,
     "recordTags": [
-        "Simulation"
+        "Simulation",
+        "SystemWaitForCompletion"
     ]
 }


### PR DESCRIPTION
### Mantis#962520
- Validated that the *Parent Data Reference* value was updated to `Input Record Only` in **Run Scenario - Create Alerts** playbook
- Validated that the scenario playbooks under the `MITRE ATT&CK Threat Hunting` solution pack are not failing and working as expected

### Mantis#0931227
- Validated that the mitre records linked to the demo record are not deleted during the scenario reset.

### Mantis#0895992
- Validated that the IRIs of created demo records are correctly added to the 'Created Records ID' field of the scenario record

### Mantis#0940683
- Validated that the `Simulate Scenario` button gets disabled during scenario playbook execution